### PR TITLE
Release v0.7.4

### DIFF
--- a/affolterNET.Web.Api/Extensions/ApplicationBuilderExtensions.cs
+++ b/affolterNET.Web.Api/Extensions/ApplicationBuilderExtensions.cs
@@ -17,6 +17,12 @@ public static class ApplicationBuilderExtensions
             app.UseMiddleware<SecurityHeadersMiddleware>();
         }
         
+        // 1.5. REQUEST LOGGING (opt-in, skips excluded paths like /health/)
+        if (apiOptions.RequestLogging.Enabled)
+        {
+            app.UseMiddleware<RequestLoggingMiddleware>();
+        }
+
         // 2. API DOCUMENTATION (Swagger/OpenAPI) - After security, before routing
         if (apiOptions.Swagger.EnableSwagger)
         {

--- a/affolterNET.Web.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/affolterNET.Web.Api/Extensions/ServiceCollectionExtensions.cs
@@ -71,8 +71,11 @@ public static class ServiceCollectionExtensions
                     ValidateLifetime = apiOptions.ApiJwtBearer.ValidateLifetime,
                     ValidateIssuerSigningKey = apiOptions.ApiJwtBearer.ValidateIssuerSigningKey,
                     ValidIssuers = apiOptions.ApiJwtBearer.ValidIssuers.Length > 0 ? apiOptions.ApiJwtBearer.ValidIssuers : null,
-                    ValidAudiences =
-                        apiOptions.ApiJwtBearer.ValidAudiences.Length > 0 ? apiOptions.ApiJwtBearer.ValidAudiences : null,
+                    ValidAudiences = apiOptions.ApiJwtBearer.ValidAudiences.Length > 0
+                        ? apiOptions.ApiJwtBearer.ValidAudiences
+                        : apiOptions.ApiJwtBearer.ValidateAudience && !string.IsNullOrEmpty(apiOptions.AuthProvider.ClientId)
+                            ? [apiOptions.AuthProvider.ClientId]
+                            : null,
                     ClockSkew = apiOptions.ApiJwtBearer.ClockSkew,
                     RoleClaimType = "roles",
                 };

--- a/affolterNET.Web.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/affolterNET.Web.Api/Extensions/ServiceCollectionExtensions.cs
@@ -59,8 +59,7 @@ public static class ServiceCollectionExtensions
         services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(options =>
             {
-                // options.Authority = authProviderOptions.Authority;
-                // options.Audience = authProviderOptions.Audience;
+                options.Authority = apiOptions.AuthProvider.Authority;
                 options.RequireHttpsMetadata = apiOptions.ApiJwtBearer.RequireHttpsMetadata;
                 options.SaveToken = apiOptions.ApiJwtBearer.SaveToken;
                 options.MapInboundClaims = false;

--- a/affolterNET.Web.Api/affolterNET.Web.Api.csproj
+++ b/affolterNET.Web.Api/affolterNET.Web.Api.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Api</PackageId>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
     <Authors>affolterNET</Authors>
     <Description>API authentication components for affolterNET applications</Description>
     

--- a/affolterNET.Web.Api/affolterNET.Web.Api.csproj
+++ b/affolterNET.Web.Api/affolterNET.Web.Api.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Api</PackageId>
-    <Version>0.7.4</Version>
+    <Version>0.7.5</Version>
     <Authors>affolterNET</Authors>
     <Description>API authentication components for affolterNET applications</Description>
     

--- a/affolterNET.Web.Api/affolterNET.Web.Api.csproj
+++ b/affolterNET.Web.Api/affolterNET.Web.Api.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Api</PackageId>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
     <Authors>affolterNET</Authors>
     <Description>API authentication components for affolterNET applications</Description>
     

--- a/affolterNET.Web.Bff/Extensions/ApplicationBuilderExtensions.cs
+++ b/affolterNET.Web.Bff/Extensions/ApplicationBuilderExtensions.cs
@@ -35,6 +35,12 @@ public static class ApplicationBuilderExtensions
             app.UseMiddleware<SecurityHeadersMiddleware>();
         }
 
+        // 2.5. REQUEST LOGGING (opt-in, skips excluded paths like /health/)
+        if (bffOptions.RequestLogging.Enabled)
+        {
+            app.UseMiddleware<RequestLoggingMiddleware>();
+        }
+
         // 3. HTTPS REDIRECTION
         if (bffOptions.Bff.EnableHttpsRedirection)
         {

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PackageId>affolterNET.Web.Bff</PackageId>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
     <Authors>affolterNET</Authors>
     <Description>BFF authentication components for web applications</Description>
     

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PackageId>affolterNET.Web.Bff</PackageId>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
     <Authors>affolterNET</Authors>
     <Description>BFF authentication components for web applications</Description>
     

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PackageId>affolterNET.Web.Bff</PackageId>
-    <Version>0.7.4</Version>
+    <Version>0.7.5</Version>
     <Authors>affolterNET</Authors>
     <Description>BFF authentication components for web applications</Description>
     

--- a/affolterNET.Web.Core/Configuration/RequestLoggingOptions.cs
+++ b/affolterNET.Web.Core/Configuration/RequestLoggingOptions.cs
@@ -1,0 +1,40 @@
+using affolterNET.Web.Core.Models;
+using affolterNET.Web.Core.Options;
+
+namespace affolterNET.Web.Core.Configuration;
+
+public class RequestLoggingOptions : IConfigurableOptions<RequestLoggingOptions>
+{
+    public static string SectionName => "affolterNET:Web:RequestLogging";
+
+    public static RequestLoggingOptions CreateDefaults(AppSettings settings)
+    {
+        return new RequestLoggingOptions(settings);
+    }
+
+    public RequestLoggingOptions() : this(new AppSettings())
+    {
+    }
+
+    public void CopyTo(RequestLoggingOptions target)
+    {
+        target.Enabled = Enabled;
+        target.ExcludePaths = ExcludePaths;
+    }
+
+    private RequestLoggingOptions(AppSettings settings)
+    {
+        Enabled = false;
+        ExcludePaths = ["/health/"];
+    }
+
+    /// <summary>
+    /// Enable request logging middleware (default: false)
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Path prefixes to exclude from logging (default: ["/health/"])
+    /// </summary>
+    public string[] ExcludePaths { get; set; }
+}

--- a/affolterNET.Web.Core/Middleware/RequestLoggingMiddleware.cs
+++ b/affolterNET.Web.Core/Middleware/RequestLoggingMiddleware.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using affolterNET.Web.Core.Configuration;
+
+namespace affolterNET.Web.Core.Middleware;
+
+public class RequestLoggingMiddleware(
+    RequestDelegate next,
+    IOptionsMonitor<RequestLoggingOptions> options,
+    ILogger<RequestLoggingMiddleware> logger)
+{
+    public async Task Invoke(HttpContext context)
+    {
+        var path = context.Request.Path.Value ?? "";
+
+        if (IsExcluded(path))
+        {
+            await next(context);
+            return;
+        }
+
+        logger.LogInformation("Request: {Method} {Path}", context.Request.Method, path);
+        await next(context);
+        var endpoint = context.GetEndpoint();
+        logger.LogInformation("Matched Endpoint: {Endpoint}", endpoint?.DisplayName ?? "None");
+    }
+
+    private bool IsExcluded(string path)
+    {
+        var excludePaths = options.CurrentValue.ExcludePaths;
+        foreach (var prefix in excludePaths)
+        {
+            if (path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/affolterNET.Web.Core/Options/CoreAppOptions.cs
+++ b/affolterNET.Web.Core/Options/CoreAppOptions.cs
@@ -20,6 +20,7 @@ public abstract class CoreAppOptions
         Swagger = config.CreateFromConfig<SwaggerOptions>(appSettings);
         Cors = config.CreateFromConfig<AffolterNetCorsOptions>(appSettings);
         Cloud = config.CreateFromConfig<CloudOptions>(appSettings);
+        RequestLogging = config.CreateFromConfig<RequestLoggingOptions>(appSettings);
         IsDev = appSettings.IsDev;
     }
     
@@ -54,6 +55,9 @@ public abstract class CoreAppOptions
     public CloudOptions Cloud { get; set; }
     public Action<CloudOptions>? ConfigureCloud { get; set; }
 
+    public RequestLoggingOptions RequestLogging { get; set; }
+    public Action<RequestLoggingOptions>? ConfigureRequestLogging { get; set; }
+
     protected void RunCoreActions(ConfigureActions? actions = null)
     {
         actions ??= new ConfigureActions(); // create if null
@@ -65,7 +69,8 @@ public abstract class CoreAppOptions
         actions.Add(ConfigureSwagger);
         actions.Add(ConfigureCors);
         actions.Add(ConfigureCloud);
-        
+        actions.Add(ConfigureRequestLogging);
+
         AuthProvider.RunActions(actions);
         Oidc.RunActions(actions);
         OidcClaimTypes.RunActions(actions);
@@ -74,6 +79,7 @@ public abstract class CoreAppOptions
         Swagger.RunActions(actions);
         Cors.RunActions(actions);
         Cloud.RunActions(actions);
+        RequestLogging.RunActions(actions);
     }
 
     protected void ConfigureCoreDi(IServiceCollection services)
@@ -86,6 +92,7 @@ public abstract class CoreAppOptions
         Swagger.ConfigureDi(services);
         Cors.ConfigureDi(services);
         Cloud.ConfigureDi(services);
+        RequestLogging.ConfigureDi(services);
     }
 
     protected abstract Dictionary<string, object> GetConfigs();
@@ -107,6 +114,7 @@ public abstract class CoreAppOptions
         Swagger.AddToConfigurationDict(dict);
         Cors.AddToConfigurationDict(dict);
         Cloud.AddToConfigurationDict(dict);
+        RequestLogging.AddToConfigurationDict(dict);
 
         var options = new JsonSerializerOptions
         {

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Core</PackageId>
-    <Version>0.7.3</Version>
+    <Version>0.7.4</Version>
     <Authors>affolterNET</Authors>
     <Description>Core authentication and authorization components for web applications</Description>
     

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Core</PackageId>
-    <Version>0.7.2</Version>
+    <Version>0.7.3</Version>
     <Authors>affolterNET</Authors>
     <Description>Core authentication and authorization components for web applications</Description>
     

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Core</PackageId>
-    <Version>0.7.4</Version>
+    <Version>0.7.5</Version>
     <Authors>affolterNET</Authors>
     <Description>Core authentication and authorization components for web applications</Description>
     


### PR DESCRIPTION
## Summary
- fix(api): auto-populate ValidAudiences with ClientId when not specified
- feat(core): add configurable request logging middleware
- fix(api): set JWT Bearer Authority from AuthProvider config
- fix(auth): disable inbound claim mapping for JWT Bearer handlers
- feat(bff): add opt-in JWT Bearer as secondary auth scheme
- And more fixes and features since v0.3.19

## Test plan
- [x] CI build and tests pass on develop
- [ ] Verify JWT audience validation works with Keycloak audience mapper
- [ ] Verify docker-compose e2e tests pass without ValidateAudience=false

🤖 Generated with [Claude Code](https://claude.com/claude-code)