### PR TITLE
feat: auth extension points for BFF consumers

### DIFF
--- a/affolterNET.Web.Api/affolterNET.Web.Api.csproj
+++ b/affolterNET.Web.Api/affolterNET.Web.Api.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Api</PackageId>
-    <Version>0.7.5</Version>
+    <Version>0.7.6</Version>
     <Authors>affolterNET</Authors>
     <Description>API authentication components for affolterNET applications</Description>
     

--- a/affolterNET.Web.Bff/Configuration/BffJwtBearerOptions.cs
+++ b/affolterNET.Web.Bff/Configuration/BffJwtBearerOptions.cs
@@ -28,6 +28,7 @@ public class BffJwtBearerOptions : IConfigurableOptions<BffJwtBearerOptions>
         target.ClockSkew = ClockSkew;
         target.ValidAudiences = ValidAudiences;
         target.ValidIssuers = ValidIssuers;
+        target.ValidAuthorizedParties = ValidAuthorizedParties;
         target.RoleClaimType = RoleClaimType;
     }
 
@@ -46,6 +47,7 @@ public class BffJwtBearerOptions : IConfigurableOptions<BffJwtBearerOptions>
         ClockSkew = TimeSpan.FromMinutes(5);
         ValidAudiences = [];
         ValidIssuers = [];
+        ValidAuthorizedParties = [];
         RoleClaimType = "roles";
     }
 
@@ -97,6 +99,13 @@ public class BffJwtBearerOptions : IConfigurableOptions<BffJwtBearerOptions>
     /// Falls back to AuthProvider.Authority if empty.
     /// </summary>
     public string[] ValidIssuers { get; set; }
+
+    /// <summary>
+    /// Valid authorized parties (azp claim) for token validation.
+    /// Common for Keycloak client credentials tokens where aud="account".
+    /// When set, audience validation is automatically disabled and azp is validated instead.
+    /// </summary>
+    public string[] ValidAuthorizedParties { get; set; }
 
     /// <summary>
     /// Claim type used for role-based authorization.

--- a/affolterNET.Web.Bff/Extensions/ServiceCollectionExtensions.cs
+++ b/affolterNET.Web.Bff/Extensions/ServiceCollectionExtensions.cs
@@ -44,7 +44,7 @@ public static class ServiceCollectionExtensions
         services.AddCoreServices()
             .AddKeycloakIntegration(bffOptions)
             .AddRptServices()
-            .AddAuthorizationPolicies();
+            .AddAuthorizationPolicies(bffOptions.ConfigureAuthorizationPolicies);
 
         // Swagger
         services.AddSwagger(bffOptions);
@@ -246,8 +246,30 @@ public static class ServiceCollectionExtensions
                     RoleClaimType = bffOptions.JwtBearer.RoleClaimType,
                     ClockSkew = bffOptions.JwtBearer.ClockSkew,
                 };
+
+                // azp validation for Keycloak client credentials tokens
+                var validAzps = bffOptions.JwtBearer.ValidAuthorizedParties;
+                if (validAzps.Length > 0)
+                {
+                    options.TokenValidationParameters.ValidateAudience = false;
+                    options.Events = new JwtBearerEvents
+                    {
+                        OnTokenValidated = context =>
+                        {
+                            var azp = context.Principal?.FindFirst("azp")?.Value;
+                            if (azp == null || !validAzps.Contains(azp))
+                            {
+                                context.Fail("Invalid authorized party (azp)");
+                            }
+                            return Task.CompletedTask;
+                        }
+                    };
+                }
             });
         }
+
+        // Allow consumer to register additional auth schemes (e.g., BasicAuth)
+        bffOptions.ConfigureAdditionalAuthSchemes?.Invoke(authBuilder);
 
         // Register BFF-specific services (only services from this library)
         services.AddSingleton<TokenRefreshService>();

--- a/affolterNET.Web.Bff/Options/BffAppOptions.cs
+++ b/affolterNET.Web.Bff/Options/BffAppOptions.cs
@@ -3,6 +3,8 @@ using affolterNET.Web.Core.Configuration;
 using affolterNET.Web.Core.Extensions;
 using affolterNET.Web.Core.Options;
 using affolterNET.Web.Core.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -51,7 +53,21 @@ public class BffAppOptions : CoreAppOptions
 
     public BffJwtBearerOptions JwtBearer { get; set; }
     public Action<BffJwtBearerOptions>? ConfigureJwtBearer { get; set; }
-    
+
+    /// <summary>
+    /// Optional callback to register additional authentication schemes
+    /// (e.g., BasicAuth, API key) on the AuthenticationBuilder.
+    /// Called after Cookie, OIDC, and JWT Bearer schemes are registered.
+    /// </summary>
+    public Action<AuthenticationBuilder>? ConfigureAdditionalAuthSchemes { get; set; }
+
+    /// <summary>
+    /// Optional callback to register authorization policies.
+    /// The library does not register any default policies — each project
+    /// defines its own role-based policies here.
+    /// </summary>
+    public Action<AuthorizationOptions>? ConfigureAuthorizationPolicies { get; set; }
+
     /// <summary>
     /// Configuration action for custom middleware - called before endpoint mapping
     /// </summary>

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PackageId>affolterNET.Web.Bff</PackageId>
-    <Version>0.7.5</Version>
+    <Version>0.7.6</Version>
     <Authors>affolterNET</Authors>
     <Description>BFF authentication components for web applications</Description>
     

--- a/affolterNET.Web.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/affolterNET.Web.Core/Extensions/ServiceCollectionExtensions.cs
@@ -78,20 +78,13 @@ public static class ServiceCollectionExtensions
     /// <summary>
     /// Adds authorization policies and custom authorization handlers
     /// </summary>
-    public static IServiceCollection AddAuthorizationPolicies(this IServiceCollection services)
+    public static IServiceCollection AddAuthorizationPolicies(
+        this IServiceCollection services,
+        Action<AuthorizationOptions>? configurePolicies = null)
     {
-        // Add authorization and custom policy provider/handler
         services.AddAuthorization(options =>
         {
-            // Add predefined role-based policies
-            options.AddPolicy("AdminOnly", policy =>
-                policy.RequireRole("admin"));
-
-            options.AddPolicy("UserOrAdmin", policy =>
-                policy.RequireRole("user", "admin"));
-
-            options.AddPolicy("CustomerOrAdmin", policy =>
-                policy.RequireRole("Customer", "admin"));
+            configurePolicies?.Invoke(options);
         });
 
         services.AddSingleton<IAuthorizationPolicyProvider, PermissionAuthorizationPolicyProvider>();

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Core</PackageId>
-    <Version>0.7.5</Version>
+    <Version>0.7.6</Version>
     <Authors>affolterNET</Authors>
     <Description>Core authentication and authorization components for web applications</Description>
     


### PR DESCRIPTION
## Summary
- Add `ValidAuthorizedParties` to `BffJwtBearerOptions` for Keycloak M2M `azp` claim validation (auto-disables audience validation when set)
- Add `ConfigureAdditionalAuthSchemes` callback on `BffAppOptions` for custom auth schemes (e.g., BasicAuth)
- Add `ConfigureAuthorizationPolicies` callback on `BffAppOptions` for consumer-defined policies
- Remove hardcoded authorization policies (`AdminOnly`, `UserOrAdmin`, `CustomerOrAdmin`) — no consumer used them

## Test plan
- [x] Library builds clean (0 errors, 0 warnings)
- [x] GP-DataFlow backend builds clean with project references
- [ ] CI build and test pass
- [ ] NuGet packages publish after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)