### PR TITLE
feat(health): decouple keycloak from readiness, add warm-up service

### DIFF
--- a/affolterNET.Web.Core/Extensions/HealthCheckEndpointExtensions.cs
+++ b/affolterNET.Web.Core/Extensions/HealthCheckEndpointExtensions.cs
@@ -46,25 +46,45 @@ public static class HealthCheckEndpointExtensions
                 [HealthStatus.Degraded] = StatusCodes.Status200OK,
                 [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
             },
-            ResponseWriter = async (context, report) =>
+            ResponseWriter = WriteJsonReport,
+        }).WithOrder(HealthCheckRouteOrder);
+
+        // Detail endpoint: runs ALL registered checks (including "detail"-tagged
+        // external-dependency checks like Keycloak). Always returns 200 so it's
+        // not a load-bearing probe — purely a diagnostic for ops. Reverse-proxy
+        // exposure of this path should be gated by auth in the consuming app.
+        endpoints.MapHealthChecks("/health/detail", new HealthCheckOptions
+        {
+            Predicate = _ => true,
+            AllowCachingResponses = false,
+            ResultStatusCodes =
             {
-                context.Response.ContentType = "application/json";
-                var result = new
-                {
-                    status = report.Status.ToString(),
-                    totalDuration = report.TotalDuration.TotalMilliseconds,
-                    checks = report.Entries.Select(e => new
-                    {
-                        name = e.Key,
-                        status = e.Value.Status.ToString(),
-                        description = e.Value.Description,
-                        duration = e.Value.Duration.TotalMilliseconds
-                    })
-                };
-                await context.Response.WriteAsJsonAsync(result);
-            }
+                [HealthStatus.Healthy] = StatusCodes.Status200OK,
+                [HealthStatus.Degraded] = StatusCodes.Status200OK,
+                [HealthStatus.Unhealthy] = StatusCodes.Status200OK,
+            },
+            ResponseWriter = WriteJsonReport,
         }).WithOrder(HealthCheckRouteOrder);
 
         return endpoints;
+    }
+
+    private static async Task WriteJsonReport(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "application/json";
+        var result = new
+        {
+            status = report.Status.ToString(),
+            totalDuration = report.TotalDuration.TotalMilliseconds,
+            checks = report.Entries.Select(e => new
+            {
+                name = e.Key,
+                status = e.Value.Status.ToString(),
+                description = e.Value.Description,
+                duration = e.Value.Duration.TotalMilliseconds,
+                tags = e.Value.Tags,
+            })
+        };
+        await context.Response.WriteAsJsonAsync(result);
     }
 }

--- a/affolterNET.Web.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/affolterNET.Web.Core/Extensions/ServiceCollectionExtensions.cs
@@ -206,10 +206,16 @@ public static class ServiceCollectionExtensions
             .AddCheck<StartupHealthCheck>("startup", tags: new[] { "startup" })
             .AddCheck("self", () => HealthCheckResult.Healthy("OK"));
 
-        // keycloak health check only if URL provided
+        // keycloak health check only if URL provided.
+        // Tagged "detail" only — NOT "ready" or "startup". An unreachable
+        // Keycloak must not take this container out of rotation; auth failures
+        // surface to the user as 401, not as a probe-induced 503. The warm-up
+        // service below wakes Keycloak's JVM in parallel with our boot so the
+        // first auth flow doesn't pay the cold-start cost.
         if (!string.IsNullOrEmpty(keycloakBaseUrl))
         {
-            health.AddCheck<KeycloakHealthCheck>("keycloak", tags: new[] { "ready", "startup" });
+            health.AddCheck<KeycloakHealthCheck>("keycloak", tags: new[] { "detail" });
+            services.AddHostedService<KeycloakWarmupService>();
         }
 
         return services;

--- a/affolterNET.Web.Core/HealthChecks/KeycloakWarmupService.cs
+++ b/affolterNET.Web.Core/HealthChecks/KeycloakWarmupService.cs
@@ -1,0 +1,61 @@
+using affolterNET.Web.Core.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace affolterNET.Web.Core.HealthChecks;
+
+/// <summary>
+/// Fires a fire-and-forget request to Keycloak's <c>.well-known/openid-configuration</c>
+/// endpoint shortly after app start. Wakes the Keycloak JVM in parallel with this app's
+/// boot so the first user-driven auth flow doesn't pay the cold-start cost.
+/// Decoupled from the readiness/startup probes so a slow or unreachable Keycloak does
+/// NOT take this container out of rotation.
+/// </summary>
+public class KeycloakWarmupService(
+    IHttpClientFactory http,
+    IOptions<AuthProviderOptions> authProviderOptions,
+    ILogger<KeycloakWarmupService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var realm = authProviderOptions.Value.Realm;
+        if (string.IsNullOrEmpty(realm))
+        {
+            return;
+        }
+
+        var client = http.CreateClient("keycloak");
+        var url = $"realms/{realm}/.well-known/openid-configuration";
+
+        for (var attempt = 1; attempt <= 3 && !stoppingToken.IsCancellationRequested; attempt++)
+        {
+            try
+            {
+                using var res = await client.GetAsync(url, stoppingToken);
+                if (res.IsSuccessStatusCode)
+                {
+                    logger.LogInformation(
+                        "Keycloak warm-up succeeded on attempt {Attempt}", attempt);
+                    return;
+                }
+                logger.LogDebug(
+                    "Keycloak warm-up attempt {Attempt} returned {Status}",
+                    attempt, (int)res.StatusCode);
+            }
+            catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
+            {
+                logger.LogDebug(ex, "Keycloak warm-up attempt {Attempt} failed", attempt);
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2 * attempt), stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Re-tag `KeycloakHealthCheck` as `"detail"` only — `/health/ready` and `/health/startup` no longer touch Keycloak, so an unreachable Keycloak no longer takes the consumer container out of rotation.
- New `KeycloakWarmupService` (`BackgroundService`) — fires 3 fire-and-forget calls to `realms/{realm}/.well-known/openid-configuration` with 2s/4s/6s backoff shortly after app start, waking the Keycloak JVM in parallel with the consumer's boot.
- New `/health/detail` endpoint — always-200, runs all registered checks (incl. Keycloak) for ops visibility.

## Why

Probe-induced cold-start failures: Container Apps default probe timeout is 1s; Keycloak's `.well-known` endpoint can take 5-30s during JVM cold-start. Result was bursts of `[ERR] Health check keycloak with status Unhealthy completed after 1000.6056ms with message 'Keycloak health check canceled'` in every consumer (e.g. GP-DataFlow saw ~9-11 errors per cold-start, multiple times per day) and 503s from `/health/ready` while Keycloak warmed up.

The probe-tag coupling was the wrong shape: an external dependency's responsiveness shouldn't gate this container's readiness. Moving the wake-up to a background service keeps the cold-start optimisation without that coupling.

## What didn't change

- `/health/live` predicate is unchanged (`Name == "self"`) — liveness never ran the Keycloak check.
- `KeycloakHealthCheck` itself is unchanged — only its tags moved.
- `keycloak` named `HttpClient` registration is unchanged (still 5s timeout).

## Test plan

- [ ] Build green locally (`dotnet build`).
- [ ] After merge to `main` and NuGet publish, bump `affolterNET.Web.*` versions in a consumer (GP-DataFlow), redeploy.
- [ ] Confirm `[ERR] Health check keycloak ...` log bursts disappear in the consumer.
- [ ] Confirm `Keycloak warm-up succeeded on attempt N` info log appears once per container start.
- [ ] Hit `/health/detail` from inside the container — should return 200 with a JSON body listing `keycloak` (status reflecting actual reachability), `startup`, `self`.
- [ ] Hit `/health/ready` while Keycloak is intentionally unreachable — should return 200 (no longer 503).