### PR TITLE
release: 0.7.7 — keycloak decoupling + azp validation

### DIFF
--- a/affolterNET.Web.Api/affolterNET.Web.Api.csproj
+++ b/affolterNET.Web.Api/affolterNET.Web.Api.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Api</PackageId>
-    <Version>0.7.6</Version>
+    <Version>0.7.7</Version>
     <Authors>affolterNET</Authors>
     <Description>API authentication components for affolterNET applications</Description>
     

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PackageId>affolterNET.Web.Bff</PackageId>
-    <Version>0.7.6</Version>
+    <Version>0.7.7</Version>
     <Authors>affolterNET</Authors>
     <Description>BFF authentication components for web applications</Description>
     

--- a/affolterNET.Web.Core/Extensions/HealthCheckEndpointExtensions.cs
+++ b/affolterNET.Web.Core/Extensions/HealthCheckEndpointExtensions.cs
@@ -46,25 +46,45 @@ public static class HealthCheckEndpointExtensions
                 [HealthStatus.Degraded] = StatusCodes.Status200OK,
                 [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
             },
-            ResponseWriter = async (context, report) =>
+            ResponseWriter = WriteJsonReport,
+        }).WithOrder(HealthCheckRouteOrder);
+
+        // Detail endpoint: runs ALL registered checks (including "detail"-tagged
+        // external-dependency checks like Keycloak). Always returns 200 so it's
+        // not a load-bearing probe — purely a diagnostic for ops. Reverse-proxy
+        // exposure of this path should be gated by auth in the consuming app.
+        endpoints.MapHealthChecks("/health/detail", new HealthCheckOptions
+        {
+            Predicate = _ => true,
+            AllowCachingResponses = false,
+            ResultStatusCodes =
             {
-                context.Response.ContentType = "application/json";
-                var result = new
-                {
-                    status = report.Status.ToString(),
-                    totalDuration = report.TotalDuration.TotalMilliseconds,
-                    checks = report.Entries.Select(e => new
-                    {
-                        name = e.Key,
-                        status = e.Value.Status.ToString(),
-                        description = e.Value.Description,
-                        duration = e.Value.Duration.TotalMilliseconds
-                    })
-                };
-                await context.Response.WriteAsJsonAsync(result);
-            }
+                [HealthStatus.Healthy] = StatusCodes.Status200OK,
+                [HealthStatus.Degraded] = StatusCodes.Status200OK,
+                [HealthStatus.Unhealthy] = StatusCodes.Status200OK,
+            },
+            ResponseWriter = WriteJsonReport,
         }).WithOrder(HealthCheckRouteOrder);
 
         return endpoints;
+    }
+
+    private static async Task WriteJsonReport(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "application/json";
+        var result = new
+        {
+            status = report.Status.ToString(),
+            totalDuration = report.TotalDuration.TotalMilliseconds,
+            checks = report.Entries.Select(e => new
+            {
+                name = e.Key,
+                status = e.Value.Status.ToString(),
+                description = e.Value.Description,
+                duration = e.Value.Duration.TotalMilliseconds,
+                tags = e.Value.Tags,
+            })
+        };
+        await context.Response.WriteAsJsonAsync(result);
     }
 }

--- a/affolterNET.Web.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/affolterNET.Web.Core/Extensions/ServiceCollectionExtensions.cs
@@ -206,10 +206,16 @@ public static class ServiceCollectionExtensions
             .AddCheck<StartupHealthCheck>("startup", tags: new[] { "startup" })
             .AddCheck("self", () => HealthCheckResult.Healthy("OK"));
 
-        // keycloak health check only if URL provided
+        // keycloak health check only if URL provided.
+        // Tagged "detail" only — NOT "ready" or "startup". An unreachable
+        // Keycloak must not take this container out of rotation; auth failures
+        // surface to the user as 401, not as a probe-induced 503. The warm-up
+        // service below wakes Keycloak's JVM in parallel with our boot so the
+        // first auth flow doesn't pay the cold-start cost.
         if (!string.IsNullOrEmpty(keycloakBaseUrl))
         {
-            health.AddCheck<KeycloakHealthCheck>("keycloak", tags: new[] { "ready", "startup" });
+            health.AddCheck<KeycloakHealthCheck>("keycloak", tags: new[] { "detail" });
+            services.AddHostedService<KeycloakWarmupService>();
         }
 
         return services;

--- a/affolterNET.Web.Core/HealthChecks/KeycloakWarmupService.cs
+++ b/affolterNET.Web.Core/HealthChecks/KeycloakWarmupService.cs
@@ -1,0 +1,61 @@
+using affolterNET.Web.Core.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace affolterNET.Web.Core.HealthChecks;
+
+/// <summary>
+/// Fires a fire-and-forget request to Keycloak's <c>.well-known/openid-configuration</c>
+/// endpoint shortly after app start. Wakes the Keycloak JVM in parallel with this app's
+/// boot so the first user-driven auth flow doesn't pay the cold-start cost.
+/// Decoupled from the readiness/startup probes so a slow or unreachable Keycloak does
+/// NOT take this container out of rotation.
+/// </summary>
+public class KeycloakWarmupService(
+    IHttpClientFactory http,
+    IOptions<AuthProviderOptions> authProviderOptions,
+    ILogger<KeycloakWarmupService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var realm = authProviderOptions.Value.Realm;
+        if (string.IsNullOrEmpty(realm))
+        {
+            return;
+        }
+
+        var client = http.CreateClient("keycloak");
+        var url = $"realms/{realm}/.well-known/openid-configuration";
+
+        for (var attempt = 1; attempt <= 3 && !stoppingToken.IsCancellationRequested; attempt++)
+        {
+            try
+            {
+                using var res = await client.GetAsync(url, stoppingToken);
+                if (res.IsSuccessStatusCode)
+                {
+                    logger.LogInformation(
+                        "Keycloak warm-up succeeded on attempt {Attempt}", attempt);
+                    return;
+                }
+                logger.LogDebug(
+                    "Keycloak warm-up attempt {Attempt} returned {Status}",
+                    attempt, (int)res.StatusCode);
+            }
+            catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
+            {
+                logger.LogDebug(ex, "Keycloak warm-up attempt {Attempt} failed", attempt);
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(2 * attempt), stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+}

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Core</PackageId>
-    <Version>0.7.6</Version>
+    <Version>0.7.7</Version>
     <Authors>affolterNET</Authors>
     <Description>Core authentication and authorization components for web applications</Description>
     


### PR DESCRIPTION
## Summary

Two features bundled into v0.7.7 NuGet release:

- **#73 — keycloak decoupled from readiness probes + warm-up service.** Re-tags `KeycloakHealthCheck` to `"detail"` only, adds `KeycloakWarmupService` (BackgroundService that fires 3 fire-and-forget calls to wake the Keycloak JVM), adds `/health/detail` ops endpoint. Eliminates probe-induced 503s and "Keycloak health check canceled" log bursts during cold-starts.
- **`e860c4c` — azp validation + custom auth schemes + custom authorization policies.** Pre-existing commit on develop, not from this session.

## Commits going to main

```
e5cf6d7 chore: bump version to 0.7.7
119de1c Merge pull request #73 from affolterNET/feature/keycloak-warmup-decoupled
7b40830 feat(health): decouple keycloak from readiness, add warm-up service
4f7dc4f chore: bump version to 0.7.6
e860c4c feat: add azp validation, custom auth schemes, and custom authorization policies
```

## Test plan

- [ ] CI publishes `affolterNET.Web.{Core,Bff,Api}` 0.7.7 to NuGet.org.
- [ ] Bump GP-DataFlow `.csproj` PackageReferences to 0.7.7, redeploy.
- [ ] Confirm `[ERR] Health check keycloak ... canceled` bursts disappear in LAW.
- [ ] Confirm `Keycloak warm-up succeeded on attempt N` info log appears once per container start.
- [ ] Confirm `/health/detail` returns 200 with all checks listed.
- [ ] Confirm `/health/ready` returns 200 even when Keycloak is unreachable.
- [ ] Smoke-test azp validation + custom auth schemes in a consuming app.