### PR TITLE
Release 0.7.8: share DataProtection between Bff and Api

### DIFF
--- a/affolterNET.Web.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/affolterNET.Web.Api/Extensions/ServiceCollectionExtensions.cs
@@ -46,6 +46,9 @@ public static class ServiceCollectionExtensions
         // Add API-specific authentication setup
         services.AddApiAuthenticationInternal(apiOptions);
 
+        // Add Data Protection key persistence (no-op when DataProtection.Enabled = false)
+        services.AddAzureBlobDataProtection(apiOptions.DataProtection);
+
         return apiOptions;
     }
 

--- a/affolterNET.Web.Api/Options/ApiAppOptions.cs
+++ b/affolterNET.Web.Api/Options/ApiAppOptions.cs
@@ -1,4 +1,5 @@
 using affolterNET.Web.Api.Configuration;
+using affolterNET.Web.Core.Configuration;
 using affolterNET.Web.Core.Extensions;
 using affolterNET.Web.Core.Options;
 using affolterNET.Web.Core.Models;
@@ -13,16 +14,20 @@ public class ApiAppOptions : CoreAppOptions
     public ApiAppOptions(AppSettings appSettings, IConfiguration config) : base(appSettings, config)
     {
         ApiJwtBearer = ApiJwtBearerOptions.CreateDefaults(appSettings);
+        DataProtection = config.CreateFromConfig<DataProtectionOptions>(appSettings);
     }
 
     public ApiJwtBearerOptions ApiJwtBearer { get; set; }
     public Action<ApiJwtBearerOptions>? ConfigureApiJwtBearer { get; set; }
-    
+
+    public DataProtectionOptions DataProtection { get; set; }
+    public Action<DataProtectionOptions>? ConfigureDataProtection { get; set; }
+
     /// <summary>
     /// Configuration action for custom middleware - called before endpoint mapping
     /// </summary>
     public Action<IApplicationBuilder>? ConfigureBeforeEndpointsCustomMiddleware { get; set; }
-    
+
     /// <summary>
     /// Configuration action for custom middleware - called after routing
     /// </summary>
@@ -32,10 +37,14 @@ public class ApiAppOptions : CoreAppOptions
     {
         var actions = new ConfigureActions();
         actions.Add(ConfigureApiJwtBearer);
-        
+        actions.Add(ConfigureDataProtection);
+
         ApiJwtBearer.RunActions(actions);
-        
+        DataProtection.RunActions(actions);
+
         RunCoreActions();
+
+        DataProtection.ConfigureDi(services);
         ConfigureCoreDi(services);
     }
 
@@ -48,7 +57,8 @@ public class ApiAppOptions : CoreAppOptions
     {
         var configDict = new Dictionary<string, object>();
         ApiJwtBearer.AddToConfigurationDict(configDict);
-        
+        DataProtection.AddToConfigurationDict(configDict);
+
         return configDict;
     }
 }

--- a/affolterNET.Web.Api/affolterNET.Web.Api.csproj
+++ b/affolterNET.Web.Api/affolterNET.Web.Api.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Api</PackageId>
-    <Version>0.7.7</Version>
+    <Version>0.7.8</Version>
     <Authors>affolterNET</Authors>
     <Description>API authentication components for affolterNET applications</Description>
     

--- a/affolterNET.Web.Bff/Extensions/ServiceCollectionExtensions.cs
+++ b/affolterNET.Web.Bff/Extensions/ServiceCollectionExtensions.cs
@@ -3,12 +3,9 @@ using affolterNET.Web.Bff.Configuration;
 using affolterNET.Web.Bff.Middleware;
 using affolterNET.Web.Bff.Options;
 using affolterNET.Web.Bff.Services;
-using Azure.Identity;
-using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
@@ -56,7 +53,7 @@ public static class ServiceCollectionExtensions
         services.AddBffAuthenticationInternal(bffOptions);
 
         // Add Data Protection key persistence
-        services.AddDataProtectionInternal(bffOptions);
+        services.AddAzureBlobDataProtection(bffOptions.DataProtection);
 
         // Add BFF supporting services
         services.AddAntiforgeryServicesInternal(bffOptions.AntiForgery);
@@ -328,44 +325,6 @@ public static class ServiceCollectionExtensions
                 : Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest;
             options.Cookie.Path = bffAntiforgeryOptions.CookiePath;
         });
-
-        return services;
-    }
-
-    /// <summary>
-    /// Adds Data Protection key persistence to Azure Blob Storage.
-    /// When disabled (default), ASP.NET Core uses ephemeral in-memory keys.
-    /// </summary>
-    private static IServiceCollection AddDataProtectionInternal(
-        this IServiceCollection services, BffAppOptions bffOptions)
-    {
-        if (!bffOptions.DataProtection.Enabled)
-        {
-            return services;
-        }
-
-        var dp = bffOptions.DataProtection;
-        var dpBuilder = services.AddDataProtection();
-
-        if (!string.IsNullOrWhiteSpace(dp.ApplicationName))
-        {
-            dpBuilder.SetApplicationName(dp.ApplicationName);
-        }
-
-        if (!string.IsNullOrWhiteSpace(dp.StorageAccountName))
-        {
-            // Managed Identity auth
-            var blobUri = new Uri(
-                $"https://{dp.StorageAccountName}.blob.core.windows.net/{dp.ContainerName}/{dp.BlobName}");
-            var credential = new ManagedIdentityCredential(dp.ManagedIdentityClientId);
-            dpBuilder.PersistKeysToAzureBlobStorage(blobUri, credential);
-        }
-        else if (!string.IsNullOrWhiteSpace(dp.ConnectionString))
-        {
-            // Connection string auth (local docker, testing)
-            var blobClient = new BlobClient(dp.ConnectionString, dp.ContainerName, dp.BlobName);
-            dpBuilder.PersistKeysToAzureBlobStorage(blobClient);
-        }
 
         return services;
     }

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PackageId>affolterNET.Web.Bff</PackageId>
-    <Version>0.7.7</Version>
+    <Version>0.7.8</Version>
     <Authors>affolterNET</Authors>
     <Description>BFF authentication components for web applications</Description>
     

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -35,8 +35,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.4.0" />
-    <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.9" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.2.0" />

--- a/affolterNET.Web.Core/Configuration/DataProtectionOptions.cs
+++ b/affolterNET.Web.Core/Configuration/DataProtectionOptions.cs
@@ -1,8 +1,7 @@
-using affolterNET.Web.Core.Configuration;
 using affolterNET.Web.Core.Models;
 using affolterNET.Web.Core.Options;
 
-namespace affolterNET.Web.Bff.Configuration;
+namespace affolterNET.Web.Core.Configuration;
 
 /// <summary>
 /// Data Protection key persistence configuration options.

--- a/affolterNET.Web.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/affolterNET.Web.Core/Extensions/ServiceCollectionExtensions.cs
@@ -1,12 +1,15 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.DataProtection;
 using affolterNET.Web.Core.Configuration;
 using affolterNET.Web.Core.Authorization;
 using affolterNET.Web.Core.HealthChecks;
 using affolterNET.Web.Core.Options;
 using affolterNET.Web.Core.Services;
 using affolterNET.Web.Core.Swagger;
+using Azure.Identity;
+using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
@@ -182,6 +185,43 @@ public static class ServiceCollectionExtensions
         {
             policy.SetPreflightMaxAge(TimeSpan.FromSeconds(affolterNetCorsOptions.MaxAge));
         }
+    }
+
+    /// <summary>
+    /// Persists ASP.NET Core Data Protection keys to Azure Blob Storage so they survive
+    /// container restarts and are shared across replicas. No-op when disabled.
+    /// </summary>
+    public static IServiceCollection AddAzureBlobDataProtection(this IServiceCollection services,
+        Configuration.DataProtectionOptions dp)
+    {
+        if (!dp.Enabled)
+        {
+            return services;
+        }
+
+        var dpBuilder = services.AddDataProtection();
+
+        if (!string.IsNullOrWhiteSpace(dp.ApplicationName))
+        {
+            dpBuilder.SetApplicationName(dp.ApplicationName);
+        }
+
+        if (!string.IsNullOrWhiteSpace(dp.StorageAccountName))
+        {
+            // Managed Identity auth
+            var blobUri = new Uri(
+                $"https://{dp.StorageAccountName}.blob.core.windows.net/{dp.ContainerName}/{dp.BlobName}");
+            var credential = new ManagedIdentityCredential(dp.ManagedIdentityClientId);
+            dpBuilder.PersistKeysToAzureBlobStorage(blobUri, credential);
+        }
+        else if (!string.IsNullOrWhiteSpace(dp.ConnectionString))
+        {
+            // Connection string auth (local docker, testing)
+            var blobClient = new BlobClient(dp.ConnectionString, dp.ContainerName, dp.BlobName);
+            dpBuilder.PersistKeysToAzureBlobStorage(blobClient);
+        }
+
+        return services;
     }
 
     public static IServiceCollection AddStandardHealthChecks(this IServiceCollection services,

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Core</PackageId>
-    <Version>0.7.7</Version>
+    <Version>0.7.8</Version>
     <Authors>affolterNET</Authors>
     <Description>Core authentication and authorization components for web applications</Description>
     

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -34,6 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.4.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
     <PackageReference Include="Keycloak.NETCore.Client" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />


### PR DESCRIPTION
## Summary
- Move `DataProtectionOptions` from `affolterNET.Web.Bff.Configuration` to `affolterNET.Web.Core.Configuration` so it can be shared.
- Add `IServiceCollection.AddAzureBlobDataProtection(DataProtectionOptions)` in `affolterNET.Web.Core` (Azure SDK refs moved here too).
- Wire DP into `ApiAppOptions` + `AddApiServices`, so JWT-bearer APIs can persist DP keys to Azure Blob Storage with the same `affolterNET:Web:DataProtection` config block as BFFs.
- `Web.Bff` now consumes the shared extension; `affolterNET:Web:DataProtection` env-var contract is unchanged for existing consumers.

## Test plan
- [x] `dotnet build` (Release) — 0 errors
- [x] `dotnet test` — Core 21/21, Api 1/1, Bff 1/1 pass
- [ ] After NuGet publish, bump `affolterNET.Web.Api` 0.7.7 → 0.7.8 in `affolterNET.FormsG.Api.csproj` and add the four `affolterNET__Web__DataProtection__*` env vars to FormsG's API container app to silence the DP warning on the API.