### PR TITLE
Release 0.8.1: heartbeat service, Node 24 CI, SecurityHeaders cleanup

### DIFF
--- a/.github/workflows/nuget-packages.yml
+++ b/.github/workflows/nuget-packages.yml
@@ -35,7 +35,7 @@ jobs:
       
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -107,7 +107,7 @@ jobs:
         fi
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -125,7 +125,7 @@ jobs:
         dotnet test affolterNET.Web.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --results-directory ./test-results
 
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: test-results
@@ -141,10 +141,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -202,13 +202,13 @@ jobs:
         ls -la ./packages/
 
     - name: Upload packages as artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: nuget-packages
         path: ./packages/*.nupkg
 
     - name: Upload symbol packages as artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: nuget-symbol-packages
         path: ./packages/*.snupkg

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,7 @@ affolterNET:Web:BffOptions        → BffOptions
 affolterNET:Web:Auth:BffAuth      → BffAuthOptions
 affolterNET:Web:Auth:CookieAuth   → CookieAuthOptions
 affolterNET:Web:Auth:AntiForgery  → BffAntiforgeryOptions
+affolterNET:Web:Heartbeat         → HeartbeatOptions
 affolterNET:ReverseProxy          → YARP configuration
 ```
 

--- a/Tests/affolterNET.Web.Core.Test/Services/HeartbeatBackgroundServiceTests.cs
+++ b/Tests/affolterNET.Web.Core.Test/Services/HeartbeatBackgroundServiceTests.cs
@@ -1,0 +1,59 @@
+using affolterNET.Web.Core.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace affolterNET.Web.Core.Services;
+
+public class HeartbeatBackgroundServiceTests
+{
+    [Fact]
+    public async Task EmitsLogLineContainingPattern_WhenEnabled()
+    {
+        var opts = new HeartbeatOptions
+        {
+            Enabled = true,
+            Pattern = "TestHeartbeat",
+            IntervalSeconds = 1,
+            LogLevel = LogLevel.Information
+        };
+        var logger = new RecordingLogger<HeartbeatBackgroundService>();
+        var svc = new HeartbeatBackgroundService(Microsoft.Extensions.Options.Options.Create(opts), logger);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(150));
+        await svc.StartAsync(cts.Token);
+        try { await Task.Delay(100, cts.Token); } catch (OperationCanceledException) { }
+        await svc.StopAsync(CancellationToken.None);
+
+        Assert.Contains(logger.Entries, e =>
+            e.Level == LogLevel.Information && e.Message.Contains("TestHeartbeat"));
+    }
+
+    [Fact]
+    public async Task DoesNotLog_WhenDisabled()
+    {
+        var opts = new HeartbeatOptions { Enabled = false, Pattern = "X", IntervalSeconds = 1 };
+        var logger = new RecordingLogger<HeartbeatBackgroundService>();
+        var svc = new HeartbeatBackgroundService(Microsoft.Extensions.Options.Options.Create(opts), logger);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+        await svc.StartAsync(cts.Token);
+        try { await Task.Delay(40, cts.Token); } catch (OperationCanceledException) { }
+        await svc.StopAsync(CancellationToken.None);
+
+        Assert.Empty(logger.Entries);
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+}

--- a/affolterNET.Web.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/affolterNET.Web.Api/Extensions/ServiceCollectionExtensions.cs
@@ -49,6 +49,9 @@ public static class ServiceCollectionExtensions
         // Add Data Protection key persistence (no-op when DataProtection.Enabled = false)
         services.AddAzureBlobDataProtection(apiOptions.DataProtection);
 
+        // Add background heartbeat for external liveness monitoring
+        services.AddHeartbeat(apiOptions.Heartbeat);
+
         return apiOptions;
     }
 

--- a/affolterNET.Web.Api/affolterNET.Web.Api.csproj
+++ b/affolterNET.Web.Api/affolterNET.Web.Api.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Api</PackageId>
-    <Version>0.7.9</Version>
+    <Version>0.8.0</Version>
     <Authors>affolterNET</Authors>
     <Description>API authentication components for affolterNET applications</Description>
     

--- a/affolterNET.Web.Api/affolterNET.Web.Api.csproj
+++ b/affolterNET.Web.Api/affolterNET.Web.Api.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Api</PackageId>
-    <Version>0.8.1</Version>
+    <Version>0.8.2</Version>
     <Authors>affolterNET</Authors>
     <Description>API authentication components for affolterNET applications</Description>
     

--- a/affolterNET.Web.Api/affolterNET.Web.Api.csproj
+++ b/affolterNET.Web.Api/affolterNET.Web.Api.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Api</PackageId>
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
     <Authors>affolterNET</Authors>
     <Description>API authentication components for affolterNET applications</Description>
     

--- a/affolterNET.Web.Api/affolterNET.Web.Api.csproj
+++ b/affolterNET.Web.Api/affolterNET.Web.Api.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Api</PackageId>
-    <Version>0.7.8</Version>
+    <Version>0.7.9</Version>
     <Authors>affolterNET</Authors>
     <Description>API authentication components for affolterNET applications</Description>
     

--- a/affolterNET.Web.Bff/Extensions/ServiceCollectionExtensions.cs
+++ b/affolterNET.Web.Bff/Extensions/ServiceCollectionExtensions.cs
@@ -55,6 +55,9 @@ public static class ServiceCollectionExtensions
         // Add Data Protection key persistence
         services.AddAzureBlobDataProtection(bffOptions.DataProtection);
 
+        // Add background heartbeat for external liveness monitoring
+        services.AddHeartbeat(bffOptions.Heartbeat);
+
         // Add BFF supporting services
         services.AddAntiforgeryServicesInternal(bffOptions.AntiForgery);
         services.AddReverseProxyInternal(configuration);

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PackageId>affolterNET.Web.Bff</PackageId>
-    <Version>0.8.1</Version>
+    <Version>0.8.2</Version>
     <Authors>affolterNET</Authors>
     <Description>BFF authentication components for web applications</Description>
     

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PackageId>affolterNET.Web.Bff</PackageId>
-    <Version>0.7.8</Version>
+    <Version>0.7.9</Version>
     <Authors>affolterNET</Authors>
     <Description>BFF authentication components for web applications</Description>
     

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PackageId>affolterNET.Web.Bff</PackageId>
-    <Version>0.7.9</Version>
+    <Version>0.8.0</Version>
     <Authors>affolterNET</Authors>
     <Description>BFF authentication components for web applications</Description>
     

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PackageId>affolterNET.Web.Bff</PackageId>
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
     <Authors>affolterNET</Authors>
     <Description>BFF authentication components for web applications</Description>
     

--- a/affolterNET.Web.Core/Configuration/HeartbeatOptions.cs
+++ b/affolterNET.Web.Core/Configuration/HeartbeatOptions.cs
@@ -1,0 +1,63 @@
+using affolterNET.Web.Core.Models;
+using affolterNET.Web.Core.Options;
+using Microsoft.Extensions.Logging;
+
+namespace affolterNET.Web.Core.Configuration;
+
+/// <summary>
+/// Heartbeat log line emitted by a background service for external liveness monitoring.
+/// An Azure Log Search alert (or similar) greps logs for <see cref="Pattern"/> and fires
+/// when no match is seen within a configured window — catching silently-stuck containers.
+/// </summary>
+public class HeartbeatOptions : IConfigurableOptions<HeartbeatOptions>
+{
+    public static string SectionName => "affolterNET:Web:Heartbeat";
+
+    public static HeartbeatOptions CreateDefaults(AppSettings settings)
+    {
+        return new HeartbeatOptions(settings);
+    }
+
+    public HeartbeatOptions() : this(new AppSettings())
+    {
+    }
+
+    private HeartbeatOptions(AppSettings settings)
+    {
+        Enabled = true;
+        Pattern = "Heartbeat";
+        IntervalSeconds = 300;
+        LogLevel = LogLevel.Information;
+    }
+
+    public void CopyTo(HeartbeatOptions target)
+    {
+        target.Enabled = Enabled;
+        target.Pattern = Pattern;
+        target.IntervalSeconds = IntervalSeconds;
+        target.LogLevel = LogLevel;
+    }
+
+    /// <summary>
+    /// Emit heartbeat log lines. Default: true.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Token included in every heartbeat log line. The external monitor greps for this exact
+    /// substring. Default: "Heartbeat". Override per-app for back-compat with existing alerts
+    /// (e.g. GP-DataFlow's alert uses "SyncHeartbeat").
+    /// </summary>
+    public string Pattern { get; set; }
+
+    /// <summary>
+    /// Seconds between heartbeats. Default: 300 (5 minutes). Pick a value comfortably below
+    /// your alert window so a single missed tick doesn't false-positive.
+    /// </summary>
+    public int IntervalSeconds { get; set; }
+
+    /// <summary>
+    /// Log level for the heartbeat line. Default: Information.
+    /// </summary>
+    public LogLevel LogLevel { get; set; }
+}

--- a/affolterNET.Web.Core/Configuration/SecurityHeadersOptions.cs
+++ b/affolterNET.Web.Core/Configuration/SecurityHeadersOptions.cs
@@ -25,8 +25,6 @@ public class SecurityHeadersOptions: IConfigurableOptions<SecurityHeadersOptions
         target.AllowedConnectSources = new List<string>(AllowedConnectSources);
         target.AllowedScriptSources = new List<string>(AllowedScriptSources);
         target.AllowedStyleSources = new List<string>(AllowedStyleSources);
-        target.AllowedStyleHashes = new List<string>(AllowedStyleHashes);
-        target.AllowInlineStyles = AllowInlineStyles;
         target.AllowedImageSources = new List<string>(AllowedImageSources);
         target.AllowDataImages = AllowDataImages;
         target.AllowBlobImages = AllowBlobImages;
@@ -65,11 +63,6 @@ public class SecurityHeadersOptions: IConfigurableOptions<SecurityHeadersOptions
         AllowedConnectSources = [];
         AllowedScriptSources = [];
         AllowedStyleSources = [];
-        AllowedStyleHashes = [
-            "'sha256-RL3ie0nH+Lzz2YNqQN83mnU0J1ot4QL7b99vMdIX99w='", // Swagger inline styles
-            "'sha256-adCHRDdBmbx4dWYaKj8Jau0AjBYObEHM9Q3PajAHatg='" // an-loader component inline styles
-        ];
-        AllowInlineStyles = settings.IsDev; // Allow unsafe-inline styles only in development
         AllowedImageSources = [];
         AllowDataImages = true; // Allow data URLs for base64 images (commonly used)
         AllowBlobImages = true; // Allow blob images in development and production
@@ -107,7 +100,6 @@ public class SecurityHeadersOptions: IConfigurableOptions<SecurityHeadersOptions
             
             // Add Vue/Vite dev server support
             AllowedScriptSources.Add("'unsafe-eval'"); // Required for Vue dev server hot reload
-            // Note: 'unsafe-inline' for styles is now controlled by AllowInlineStyles property
         }
 
         FrontendUrl = string.Empty;
@@ -137,19 +129,6 @@ public class SecurityHeadersOptions: IConfigurableOptions<SecurityHeadersOptions
     /// Additional allowed hosts for style-src directive
     /// </summary>
     public List<string> AllowedStyleSources { get; set; }
-    
-    /// <summary>
-    /// SHA-256 hashes for specific inline styles that should be allowed.
-    /// Format: 'sha256-HASH' (e.g., 'sha256-RL3ie0nH+Lzz2YNqQN83mnU0J1ot4QL7b99vMdIX99w=')
-    /// </summary>
-    [Obsolete("Style hashes are no longer used. The CSP now uses 'unsafe-inline' for style-src to support Vue/React SPAs.")]
-    public List<string> AllowedStyleHashes { get; set; }
-
-    /// <summary>
-    /// Whether to allow 'unsafe-inline' styles. No longer used - inline styles are always allowed for SPA compatibility.
-    /// </summary>
-    [Obsolete("Inline styles are now always allowed for Vue/React SPA compatibility. This property has no effect.")]
-    public bool AllowInlineStyles { get; set; }
     
     /// <summary>
     /// Additional allowed hosts for img-src directive

--- a/affolterNET.Web.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/affolterNET.Web.Core/Extensions/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Azure.Identity;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using NETCore.Keycloak.Client.HttpClients.Abstraction;
 using NETCore.Keycloak.Client.HttpClients.Implementation;
@@ -185,6 +186,24 @@ public static class ServiceCollectionExtensions
         {
             policy.SetPreflightMaxAge(TimeSpan.FromSeconds(affolterNetCorsOptions.MaxAge));
         }
+    }
+
+    /// <summary>
+    /// Registers a background service that emits a configurable heartbeat log line at a
+    /// fixed interval. The log line includes <see cref="HeartbeatOptions.Pattern"/>, which
+    /// external monitors (e.g. Azure Log Search alerts) grep for to detect stuck containers.
+    /// No-op when disabled.
+    /// </summary>
+    public static IServiceCollection AddHeartbeat(this IServiceCollection services,
+        HeartbeatOptions heartbeat)
+    {
+        if (!heartbeat.Enabled)
+        {
+            return services;
+        }
+
+        services.AddHostedService<HeartbeatBackgroundService>();
+        return services;
     }
 
     /// <summary>

--- a/affolterNET.Web.Core/Options/CoreAppOptions.cs
+++ b/affolterNET.Web.Core/Options/CoreAppOptions.cs
@@ -21,6 +21,7 @@ public abstract class CoreAppOptions
         Cors = config.CreateFromConfig<AffolterNetCorsOptions>(appSettings);
         Cloud = config.CreateFromConfig<CloudOptions>(appSettings);
         RequestLogging = config.CreateFromConfig<RequestLoggingOptions>(appSettings);
+        Heartbeat = config.CreateFromConfig<HeartbeatOptions>(appSettings);
         IsDev = appSettings.IsDev;
     }
     
@@ -58,6 +59,9 @@ public abstract class CoreAppOptions
     public RequestLoggingOptions RequestLogging { get; set; }
     public Action<RequestLoggingOptions>? ConfigureRequestLogging { get; set; }
 
+    public HeartbeatOptions Heartbeat { get; set; }
+    public Action<HeartbeatOptions>? ConfigureHeartbeat { get; set; }
+
     protected void RunCoreActions(ConfigureActions? actions = null)
     {
         actions ??= new ConfigureActions(); // create if null
@@ -70,6 +74,7 @@ public abstract class CoreAppOptions
         actions.Add(ConfigureCors);
         actions.Add(ConfigureCloud);
         actions.Add(ConfigureRequestLogging);
+        actions.Add(ConfigureHeartbeat);
 
         AuthProvider.RunActions(actions);
         Oidc.RunActions(actions);
@@ -80,6 +85,7 @@ public abstract class CoreAppOptions
         Cors.RunActions(actions);
         Cloud.RunActions(actions);
         RequestLogging.RunActions(actions);
+        Heartbeat.RunActions(actions);
     }
 
     protected void ConfigureCoreDi(IServiceCollection services)
@@ -93,6 +99,7 @@ public abstract class CoreAppOptions
         Cors.ConfigureDi(services);
         Cloud.ConfigureDi(services);
         RequestLogging.ConfigureDi(services);
+        Heartbeat.ConfigureDi(services);
     }
 
     protected abstract Dictionary<string, object> GetConfigs();
@@ -115,6 +122,7 @@ public abstract class CoreAppOptions
         Cors.AddToConfigurationDict(dict);
         Cloud.AddToConfigurationDict(dict);
         RequestLogging.AddToConfigurationDict(dict);
+        Heartbeat.AddToConfigurationDict(dict);
 
         var options = new JsonSerializerOptions
         {

--- a/affolterNET.Web.Core/Services/HeartbeatBackgroundService.cs
+++ b/affolterNET.Web.Core/Services/HeartbeatBackgroundService.cs
@@ -1,0 +1,44 @@
+using affolterNET.Web.Core.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace affolterNET.Web.Core.Services;
+
+/// <summary>
+/// Emits a heartbeat log line at a fixed interval so external monitors can detect
+/// silently-stuck containers. The line contains the configured <see cref="HeartbeatOptions.Pattern"/>
+/// substring, which an Azure Log Search alert (or equivalent) greps for.
+/// </summary>
+public class HeartbeatBackgroundService(
+    IOptions<HeartbeatOptions> options,
+    ILogger<HeartbeatBackgroundService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var opts = options.Value;
+        if (!opts.Enabled)
+        {
+            return;
+        }
+
+        var interval = TimeSpan.FromSeconds(Math.Max(1, opts.IntervalSeconds));
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // Format chosen to match the historical "SyncHeartbeat: alive at <ISO-8601 UTC>"
+            // line that existing log-search alerts already grep for.
+            logger.Log(opts.LogLevel, "{Pattern}: alive at {Timestamp:O}",
+                opts.Pattern, DateTimeOffset.UtcNow);
+
+            try
+            {
+                await Task.Delay(interval, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+}

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Core</PackageId>
-    <Version>0.8.1</Version>
+    <Version>0.8.2</Version>
     <Authors>affolterNET</Authors>
     <Description>Core authentication and authorization components for web applications</Description>
     

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Core</PackageId>
-    <Version>0.7.8</Version>
+    <Version>0.7.9</Version>
     <Authors>affolterNET</Authors>
     <Description>Core authentication and authorization components for web applications</Description>
     

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Core</PackageId>
-    <Version>0.7.9</Version>
+    <Version>0.8.0</Version>
     <Authors>affolterNET</Authors>
     <Description>Core authentication and authorization components for web applications</Description>
     

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Core</PackageId>
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
     <Authors>affolterNET</Authors>
     <Description>Core authentication and authorization components for web applications</Description>
     


### PR DESCRIPTION
## Summary
- **Heartbeat service** — `HeartbeatBackgroundService` in `affolterNET.Web.Core`, auto-registered via `AddBffServices` / `AddApiServices`. Section: `affolterNET:Web:Heartbeat` (`Pattern`, `IntervalSeconds`, `Enabled`, `LogLevel`). Apps with their own heartbeat set `Enabled=false`; GP-DataFlow keeps its existing `SyncHeartbeat` alert by setting `Pattern=SyncHeartbeat`.
- **CI: Node 24 migration** — bumped `actions/checkout`, `setup-dotnet` to v5 and `upload-artifact` to v6 to clear the June 2 2026 Node 20 deprecation deadline.
- **Docs** — added `affolterNET:Web:Heartbeat` row to the configuration section table in CLAUDE.md.

## Breaking changes
- `SecurityHeadersOptions.AllowedStyleHashes` and `SecurityHeadersOptions.AllowInlineStyles` are **removed**. Both were marked `[Obsolete]` and had no runtime effect — CSP uses `'unsafe-inline'` for `style-src` unconditionally for Vue/React SPA compatibility. Remove any C# references in consumer code; `appsettings.json` keys are silently ignored by config binding.

## Test plan
- [x] `dotnet build` (Release) — 0 warnings, 0 errors after obsolete-prop removal
- [x] `dotnet test` — all suites pass on develop CI
- [ ] After publish: rebuild GP-DataFlow / Bexio / Memo against 0.8.x and confirm CSP and heartbeat behave as before
- [ ] Confirm `SyncHeartbeat: alive at <ISO-8601>` log line still appears in Log Analytics for `gp-dataflow-prod-app`