### PR TITLE
Bump action versions and add heartbeat docs/skills

### DIFF
--- a/.github/workflows/nuget-packages.yml
+++ b/.github/workflows/nuget-packages.yml
@@ -35,7 +35,7 @@ jobs:
       
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -125,7 +125,7 @@ jobs:
         dotnet test affolterNET.Web.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --results-directory ./test-results
 
     - name: Upload test results
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       if: always()
       with:
         name: test-results
@@ -141,7 +141,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
@@ -202,13 +202,13 @@ jobs:
         ls -la ./packages/
 
     - name: Upload packages as artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: nuget-packages
         path: ./packages/*.nupkg
 
     - name: Upload symbol packages as artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: nuget-symbol-packages
         path: ./packages/*.snupkg

--- a/affolterNET.Web.Api/affolterNET.Web.Api.csproj
+++ b/affolterNET.Web.Api/affolterNET.Web.Api.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Api</PackageId>
-    <Version>0.8.2</Version>
+    <Version>0.8.3</Version>
     <Authors>affolterNET</Authors>
     <Description>API authentication components for affolterNET applications</Description>
     

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PackageId>affolterNET.Web.Bff</PackageId>
-    <Version>0.8.2</Version>
+    <Version>0.8.3</Version>
     <Authors>affolterNET</Authors>
     <Description>BFF authentication components for web applications</Description>
     

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Core</PackageId>
-    <Version>0.8.2</Version>
+    <Version>0.8.3</Version>
     <Authors>affolterNET</Authors>
     <Description>Core authentication and authorization components for web applications</Description>
     

--- a/plugins/affolternet-web-api/LIBRARY_GUIDE.md
+++ b/plugins/affolternet-web-api/LIBRARY_GUIDE.md
@@ -64,6 +64,7 @@ affolterNET:Web:PermissionCache   → PermissionCacheOptions
 affolterNET:Web:SecurityHeaders   → SecurityHeadersOptions
 affolterNET:Web:Swagger           → SwaggerOptions
 affolterNET:Web:Cors              → AffolterNetCorsOptions
+affolterNET:Web:Heartbeat         → HeartbeatOptions (liveness log line — see heartbeat skill)
 ```
 
 ## Middleware Pipeline Order

--- a/plugins/affolternet-web-api/skills/heartbeat/SKILL.md
+++ b/plugins/affolternet-web-api/skills/heartbeat/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: heartbeat
+description: Configure the periodic heartbeat log line for affolterNET.Web.Api. Use when wiring an external liveness alert (e.g. Azure Log Search alert), changing the log substring, or matching a legacy alert pattern after a library upgrade.
+---
+
+# Heartbeat (Liveness Log Line)
+
+A `HeartbeatBackgroundService` (registered automatically by `AddApiServices`) emits one log line at a fixed interval. An external monitor (Azure Log Search alert, Loki rule, etc.) greps for the configured substring and fires when no match is seen within its window — catching silently-stuck containers that still pass HTTP health probes.
+
+The service is in `affolterNET.Web.Core` and is wired from both `AddBffServices` and `AddApiServices`.
+
+## Default behavior
+
+| Property | Default | Meaning |
+|----------|---------|---------|
+| `Enabled` | `true` | Emit heartbeats. Set `false` to disable entirely. |
+| `Pattern` | `Heartbeat` | Substring included in every heartbeat line. The external monitor greps for this. |
+| `IntervalSeconds` | `300` (5 min) | Time between heartbeats. Pick comfortably below the alert window so a single missed tick can't false-positive. |
+| `LogLevel` | `Information` | Log level of the heartbeat line. |
+
+Default output:
+
+```
+[INF] Heartbeat: alive at 2026-04-29T07:35:00.0000000+00:00
+```
+
+## Configure via environment variables (recommended for containers)
+
+Standard ASP.NET Core config binding uses `__` as the section separator. The four overrides are:
+
+```bash
+affolterNET__Web__Heartbeat__Enabled=true
+affolterNET__Web__Heartbeat__Pattern=SyncHeartbeat
+affolterNET__Web__Heartbeat__IntervalSeconds=600
+affolterNET__Web__Heartbeat__LogLevel=Information
+```
+
+Terraform example for an Azure Container App:
+
+```hcl
+template {
+  container {
+    env { name = "affolterNET__Web__Heartbeat__Pattern", value = "SyncHeartbeat" }
+    env { name = "affolterNET__Web__Heartbeat__IntervalSeconds", value = "300" }
+  }
+}
+```
+
+## Configure via appsettings.json
+
+```json
+{
+  "affolterNET": {
+    "Web": {
+      "Heartbeat": {
+        "Enabled": true,
+        "Pattern": "SyncHeartbeat",
+        "IntervalSeconds": 300,
+        "LogLevel": "Information"
+      }
+    }
+  }
+}
+```
+
+## Configure programmatically
+
+```csharp
+var options = builder.Services.AddApiServices(appSettings, config, opts =>
+{
+    opts.ConfigureHeartbeat = hb =>
+    {
+        hb.Pattern = "SyncHeartbeat";
+        hb.IntervalSeconds = 300;
+    };
+});
+```
+
+The programmatic action runs *after* config binding, so values set here override env vars / `appsettings.json`.
+
+## When to override `Pattern`
+
+The default `"Heartbeat"` substring is fine for new deployments. Override it when:
+
+- **Migrating a legacy app** that already has an alert keyed on a custom substring. Set `Pattern` to that substring to keep the existing alert working without touching the alert rule.
+- **Multiple apps share one Log Analytics workspace** and you need per-app patterns to disambiguate.
+- **`"Heartbeat"` collides** with another log line in your stack.
+
+## Wiring an Azure Log Search alert
+
+```kql
+ContainerAppConsoleLogs_CL
+| where ContainerAppName_s == "<your-app>"
+| where Log_s contains "<your Pattern value>"
+```
+
+Trigger when `Count == 0` over your chosen window. Keep the window at least 2× `IntervalSeconds` so one missed tick never alerts.
+
+## Disable heartbeat
+
+For dev environments that scale to zero (cold container ⇒ no heartbeat ⇒ false positive), either:
+
+- Set `affolterNET__Web__Heartbeat__Enabled=false` on dev, or
+- Keep heartbeat on and disable the *alert* (the workbook still shows heartbeat data when the container is awake).
+
+The second is preferred: production behavior matches dev, only the alert rule differs per-env.
+
+## Heartbeat vs `/health` endpoints
+
+These complement each other — they don't overlap.
+
+| Mechanism | Detects | When it fires |
+|-----------|---------|---------------|
+| `/health` probes | HTTP listener responsive | On each scrape (Kubernetes/load balancer pulls) |
+| Heartbeat log line | Background loop alive, container reaching the logging path | Push-based, every `IntervalSeconds` |
+
+A container can pass `/health/ready` while a background service is wedged. The heartbeat catches that. See the `health-checks` skill for the HTTP probe side.
+
+## Troubleshooting
+
+### No heartbeat lines in Log Analytics
+- Confirm `Enabled` is `true` (default). Check the rendered config at startup.
+- Confirm the container is actually running — scale-to-zero apps emit nothing while asleep.
+- Wait at least `IntervalSeconds` after startup; the first heartbeat fires after one interval, not immediately.
+
+### Alert keeps firing despite container being healthy
+- Substring mismatch: the alert query's `contains` value must equal `Pattern` exactly (case-sensitive in KQL when using `contains_cs`; case-insensitive with `contains`).
+- Window too tight relative to `IntervalSeconds` — give yourself 2× margin.
+- Cold-start window: add `business_hours` scoping or raise the window for scale-to-zero apps.
+
+### After library upgrade, alert went silent
+- The default `Pattern` changed (or didn't) between versions; pin it explicitly via env var instead of relying on the default. This makes the alert stable across library bumps.

--- a/plugins/affolternet-web-bff/LIBRARY_GUIDE.md
+++ b/plugins/affolternet-web-bff/LIBRARY_GUIDE.md
@@ -74,6 +74,7 @@ affolterNET:Web:BffOptions        → BffOptions
 affolterNET:Web:Auth:BffAuth      → BffAuthOptions
 affolterNET:Web:Auth:CookieAuth   → CookieAuthOptions
 affolterNET:Web:Auth:AntiForgery  → BffAntiforgeryOptions
+affolterNET:Web:Heartbeat         → HeartbeatOptions (liveness log line — see heartbeat skill)
 affolterNET:ReverseProxy          → YARP configuration
 ```
 

--- a/plugins/affolternet-web-bff/skills/heartbeat/SKILL.md
+++ b/plugins/affolternet-web-bff/skills/heartbeat/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: heartbeat
+description: Configure the periodic heartbeat log line for affolterNET.Web.Bff. Use when wiring an external liveness alert (e.g. Azure Log Search alert), changing the log substring, or matching a legacy alert pattern after a library upgrade.
+---
+
+# Heartbeat (Liveness Log Line)
+
+A `HeartbeatBackgroundService` (registered automatically by `AddBffServices`) emits one log line at a fixed interval. An external monitor (Azure Log Search alert, Loki rule, etc.) greps for the configured substring and fires when no match is seen within its window — catching silently-stuck containers that still pass HTTP health probes.
+
+The service is in `affolterNET.Web.Core` and is wired from both `AddBffServices` and `AddApiServices`.
+
+## Default behavior
+
+| Property | Default | Meaning |
+|----------|---------|---------|
+| `Enabled` | `true` | Emit heartbeats. Set `false` to disable entirely. |
+| `Pattern` | `Heartbeat` | Substring included in every heartbeat line. The external monitor greps for this. |
+| `IntervalSeconds` | `300` (5 min) | Time between heartbeats. Pick comfortably below the alert window so a single missed tick can't false-positive. |
+| `LogLevel` | `Information` | Log level of the heartbeat line. |
+
+Default output:
+
+```
+[INF] Heartbeat: alive at 2026-04-29T07:35:00.0000000+00:00
+```
+
+## Configure via environment variables (recommended for containers)
+
+Standard ASP.NET Core config binding uses `__` as the section separator. The four overrides are:
+
+```bash
+affolterNET__Web__Heartbeat__Enabled=true
+affolterNET__Web__Heartbeat__Pattern=SyncHeartbeat
+affolterNET__Web__Heartbeat__IntervalSeconds=600
+affolterNET__Web__Heartbeat__LogLevel=Information
+```
+
+Terraform example for an Azure Container App:
+
+```hcl
+template {
+  container {
+    env { name = "affolterNET__Web__Heartbeat__Pattern", value = "SyncHeartbeat" }
+    env { name = "affolterNET__Web__Heartbeat__IntervalSeconds", value = "300" }
+  }
+}
+```
+
+## Configure via appsettings.json
+
+```json
+{
+  "affolterNET": {
+    "Web": {
+      "Heartbeat": {
+        "Enabled": true,
+        "Pattern": "SyncHeartbeat",
+        "IntervalSeconds": 300,
+        "LogLevel": "Information"
+      }
+    }
+  }
+}
+```
+
+## Configure programmatically
+
+```csharp
+var options = builder.Services.AddBffServices(appSettings, config, opts =>
+{
+    opts.ConfigureHeartbeat = hb =>
+    {
+        hb.Pattern = "SyncHeartbeat";
+        hb.IntervalSeconds = 300;
+    };
+});
+```
+
+The programmatic action runs *after* config binding, so values set here override env vars / `appsettings.json`.
+
+## When to override `Pattern`
+
+The default `"Heartbeat"` substring is fine for new deployments. Override it when:
+
+- **Migrating a legacy app** that already has an alert keyed on a custom substring (e.g. GP-DataFlow's pre-library inline log line used `"SyncHeartbeat"`). Set `Pattern=SyncHeartbeat` to keep the existing alert working without touching the alert rule.
+- **Multiple apps share one Log Analytics workspace** and you need per-app patterns to disambiguate.
+- **`"Heartbeat"` collides** with another log line in your stack.
+
+## Wiring an Azure Log Search alert
+
+```kql
+ContainerAppConsoleLogs_CL
+| where ContainerAppName_s == "<your-app>"
+| where Log_s contains "<your Pattern value>"
+```
+
+Trigger when `Count == 0` over your chosen window. Keep the window at least 2× `IntervalSeconds` so one missed tick never alerts.
+
+## Disable heartbeat
+
+For dev environments that scale to zero (cold container ⇒ no heartbeat ⇒ false positive), either:
+
+- Set `affolterNET__Web__Heartbeat__Enabled=false` on dev, or
+- Keep heartbeat on and disable the *alert* (the workbook still shows heartbeat data when the container is awake).
+
+The second is preferred: production behavior matches dev, only the alert rule differs per-env.
+
+## Troubleshooting
+
+### No heartbeat lines in Log Analytics
+- Confirm `Enabled` is `true` (default). Check the rendered config at startup.
+- Confirm the container is actually running — scale-to-zero apps emit nothing while asleep.
+- Wait at least `IntervalSeconds` after startup; the first heartbeat fires after one interval, not immediately.
+
+### Alert keeps firing despite container being healthy
+- Substring mismatch: the alert query's `contains` value must equal `Pattern` exactly (case-sensitive in KQL when using `contains_cs`; case-insensitive with `contains`).
+- Window too tight relative to `IntervalSeconds` — give yourself 2× margin.
+- Cold-start window: add `business_hours` scoping or raise the window for scale-to-zero apps.
+
+### After library upgrade, alert went silent
+- The default `Pattern` changed (or didn't) between versions; pin it explicitly via env var instead of relying on the default. This makes the alert stable across library bumps.


### PR DESCRIPTION
## Summary
- Bump GitHub Action versions in nuget-packages.yml: `actions/checkout@v5→v6`, `actions/upload-artifact@v6→v7`. All 3 upload sites use multi-file glob paths, so v7's no-zip single-file behavior does not affect them.
- Document the `affolterNET:Web:Heartbeat` config section in both `LIBRARY_GUIDE.md` files.
- Add `skills/heartbeat/SKILL.md` to both api and bff plugins documenting the existing `HeartbeatBackgroundService` (config via env vars / appsettings / programmatic, Azure Log Search alert wiring, troubleshooting).

## Test plan
- [x] CI green on develop (run 25097678172)
- [ ] On merge to main: NuGet packages publish to nuget.org with the patch-bumped version