### PR TITLE
Release 0.8.4: BFF token refresh log-level fix

### DIFF
--- a/affolterNET.Web.Api/affolterNET.Web.Api.csproj
+++ b/affolterNET.Web.Api/affolterNET.Web.Api.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Api</PackageId>
-    <Version>0.8.3</Version>
+    <Version>0.8.4</Version>
     <Authors>affolterNET</Authors>
     <Description>API authentication components for affolterNET applications</Description>
     

--- a/affolterNET.Web.Bff/Services/TokenRefreshService.cs
+++ b/affolterNET.Web.Bff/Services/TokenRefreshService.cs
@@ -144,7 +144,20 @@ public class TokenRefreshService(
         var kcResponse = await keycloakClient.Auth.RefreshAccessTokenAsync(_realm, _clientCredentials, refreshToken);
         if (kcResponse.IsError)
         {
-            logger.LogError("Refreshing tokens failed: {Error}", kcResponse.ErrorMessage);
+            // invalid_grant ("Session not active" / "Token is not active" / "Refresh token expired")
+            // is the routine outcome when a user's Keycloak session has been idle past
+            // SSO Session Idle / Refresh Token Lifespan. The middleware handles it correctly
+            // (clear cookie → 401 → SPA redirects to login); logging at Error here would
+            // trigger alerts for every routine session expiry.
+            var msg = kcResponse.ErrorMessage ?? string.Empty;
+            if (msg.Contains("invalid_grant", StringComparison.OrdinalIgnoreCase))
+            {
+                logger.LogInformation("Refresh token rejected by Keycloak (session likely expired): {Error}", msg);
+            }
+            else
+            {
+                logger.LogError("Refreshing tokens failed: {Error}", msg);
+            }
             return null;
         }
 

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PackageId>affolterNET.Web.Bff</PackageId>
-    <Version>0.8.3</Version>
+    <Version>0.8.4</Version>
     <Authors>affolterNET</Authors>
     <Description>BFF authentication components for web applications</Description>
     

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Core</PackageId>
-    <Version>0.8.3</Version>
+    <Version>0.8.4</Version>
     <Authors>affolterNET</Authors>
     <Description>Core authentication and authorization components for web applications</Description>
     


### PR DESCRIPTION
## Summary

- `fix(bff)`: routine session-expiry from Keycloak (`invalid_grant` / "Session not active" / "Token is not active") now logs at Information instead of Error in `TokenRefreshService.RequestNewTokensAsync`. Genuine refresh failures (network errors, malformed responses) still log at Error.
- `chore`: version bump 0.8.3 → 0.8.4 (auto-bump on develop).

## Why

The previous behaviour logged every routine user session-idle event as an Error, which polluted Application Insights and triggered error alerts for normal session-timeout flows on consumers (e.g. GP-FormsG prod, ~6 events/day). The middleware already handles the case correctly (clear cookie → 401 → SPA redirects to login), so the log severity was the only thing wrong.

## Test plan

- [x] Build succeeds (\`dotnet build affolterNET.Web.sln --configuration Release\`)
- [x] All existing tests pass (25 total)
- [ ] After publish: verify \`affolterNET.Web.Bff 0.8.4\` on nuget.org
- [ ] After consumer bump: confirm prod logs no longer show \`Error]: Refreshing tokens failed\` for invalid_grant cases