### PR TITLE
feat: single RPT gate via PermissionCacheOptions.Enabled (0.9.0)

### DIFF
--- a/Tests/affolterNET.Web.Core.Test/Services/PermissionServiceGateTests.cs
+++ b/Tests/affolterNET.Web.Core.Test/Services/PermissionServiceGateTests.cs
@@ -1,0 +1,53 @@
+using affolterNET.Web.Core.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace affolterNET.Web.Core.Services;
+
+/// <summary>
+/// Tests for the master gate added in <see cref="PermissionService.GetUserPermissionsAsync"/>:
+/// when <see cref="PermissionCacheOptions.Enabled"/> is false, the method must short-circuit
+/// and never touch <see cref="RptTokenService"/>. This is the regression guard for the
+/// "Client does not support permissions" warning that fired on every login when the Keycloak
+/// client did not have the UMA Authorization feature enabled.
+/// </summary>
+public class PermissionServiceGateTests
+{
+    [Fact]
+    public async Task GetUserPermissionsAsync_ReturnsEmpty_WhenDisabled()
+    {
+        // Arrange — construct PermissionService with the gate flipped off.
+        // Other dependencies pass null! because the early-return must trigger
+        // before any other field is touched. If the gate is broken, the test
+        // will throw NRE on rptTokenService / cache / etc.
+        var monitor = new TestOptionsMonitor<PermissionCacheOptions>(
+            new PermissionCacheOptions { Enabled = false });
+        var sut = new PermissionService(
+            rptTokenService: null!,
+            rptCacheService: null!,
+            cache: null!,
+            httpContextAccessor: null!,
+            logger: Microsoft.Extensions.Logging.Abstractions.NullLogger<PermissionService>.Instance,
+            permissionCacheOptions: monitor);
+
+        // Act
+        var result = await sut.GetUserPermissionsAsync("user-1", "any-access-token");
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    private sealed class TestOptionsMonitor<T>(T currentValue) : IOptionsMonitor<T>
+    {
+        public T CurrentValue { get; } = currentValue;
+
+        public T Get(string? name) => CurrentValue;
+
+        public IDisposable OnChange(Action<T, string?> listener) => NullDisposable.Instance;
+
+        private sealed class NullDisposable : IDisposable
+        {
+            public static readonly NullDisposable Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/affolterNET.Web.Api/Extensions/ApplicationBuilderExtensions.cs
+++ b/affolterNET.Web.Api/Extensions/ApplicationBuilderExtensions.cs
@@ -52,7 +52,10 @@ public static class ApplicationBuilderExtensions
         if (apiOptions.ApiJwtBearer.AuthMode != AuthenticationMode.None)
         {
             app.UseAuthentication();
-            app.UseMiddleware<RptMiddleware>();
+            if (apiOptions.EnableRptTokens)
+            {
+                app.UseMiddleware<RptMiddleware>();
+            }
             app.UseAuthorization();
         }
         

--- a/affolterNET.Web.Api/Options/ApiAppOptions.cs
+++ b/affolterNET.Web.Api/Options/ApiAppOptions.cs
@@ -24,6 +24,15 @@ public class ApiAppOptions : CoreAppOptions
     public Action<DataProtectionOptions>? ConfigureDataProtection { get; set; }
 
     /// <summary>
+    /// When true, register <c>RptMiddleware</c> in the request pipeline AND let
+    /// <c>ApiClaimsEnrichmentService</c> request RPT tokens during claims enrichment.
+    /// Set to false when the Keycloak client does not have the UMA Authorization
+    /// feature enabled (= role-based-only auth on JWT). Default: true.
+    /// Mirror of <c>BffOptions.EnableRptTokens</c>.
+    /// </summary>
+    public bool EnableRptTokens { get; set; } = true;
+
+    /// <summary>
     /// Configuration action for custom middleware - called before endpoint mapping
     /// </summary>
     public Action<IApplicationBuilder>? ConfigureBeforeEndpointsCustomMiddleware { get; set; }
@@ -43,6 +52,13 @@ public class ApiAppOptions : CoreAppOptions
         DataProtection.RunActions(actions);
 
         RunCoreActions();
+
+        // Single source of truth: EnableRptTokens decides whether the RPT-based
+        // permission flow runs at all. PermissionCacheOptions.Enabled is the gate
+        // read by PermissionService — propagate it here so a consumer that sets
+        // EnableRptTokens = false silences both RptMiddleware and the
+        // claims-enrichment RPT fetch with one knob.
+        PermissionCache.Enabled = EnableRptTokens;
 
         DataProtection.ConfigureDi(services);
         ConfigureCoreDi(services);

--- a/affolterNET.Web.Api/affolterNET.Web.Api.csproj
+++ b/affolterNET.Web.Api/affolterNET.Web.Api.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Api</PackageId>
-    <Version>0.8.4</Version>
+    <Version>0.9.0</Version>
     <Authors>affolterNET</Authors>
     <Description>API authentication components for affolterNET applications</Description>
     

--- a/affolterNET.Web.Bff/Options/BffAppOptions.cs
+++ b/affolterNET.Web.Bff/Options/BffAppOptions.cs
@@ -98,6 +98,13 @@ public class BffAppOptions : CoreAppOptions
         JwtBearer.RunActions(actions);
         RunCoreActions(actions);
 
+        // Single source of truth: BffOptions.EnableRptTokens decides whether the
+        // RPT-based permission flow runs at all. PermissionCacheOptions.Enabled is
+        // the gate read by PermissionService — propagate it here so a consumer that
+        // sets bffOpts.EnableRptTokens = false silences both RptMiddleware and the
+        // claims-enrichment RPT fetch with one knob.
+        PermissionCache.Enabled = Bff.EnableRptTokens;
+
         // Move config values to base types
         var baseActions = new ConfigureActions();
         Action<SecurityHeadersOptions> configureUrl = sho =>

--- a/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
+++ b/affolterNET.Web.Bff/affolterNET.Web.Bff.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <PackageId>affolterNET.Web.Bff</PackageId>
-    <Version>0.8.4</Version>
+    <Version>0.9.0</Version>
     <Authors>affolterNET</Authors>
     <Description>BFF authentication components for web applications</Description>
     

--- a/affolterNET.Web.Core/Configuration/PermissionCacheOptions.cs
+++ b/affolterNET.Web.Core/Configuration/PermissionCacheOptions.cs
@@ -21,6 +21,7 @@ public class PermissionCacheOptions: IConfigurableOptions<PermissionCacheOptions
 
     public void CopyTo(PermissionCacheOptions target)
     {
+        target.Enabled = Enabled;
         target.DefaultExpiration = DefaultExpiration;
         target.MaxCacheSize = MaxCacheSize;
         target.PermissionCacheExpiration = PermissionCacheExpiration;
@@ -43,6 +44,19 @@ public class PermissionCacheOptions: IConfigurableOptions<PermissionCacheOptions
         PermissionCacheExpiration = settings.IsDev ? TimeSpan.FromMinutes(3) : TimeSpan.FromMinutes(10); // Shorter permission cache in development
         MaxCacheSize = settings.IsDev ? 100 : 1000; // Smaller cache size in development
     }
+
+    /// <summary>
+    /// Master switch for the RPT-based permission flow. When false,
+    /// <see cref="Services.PermissionService.GetUserPermissionsAsync"/> short-circuits
+    /// and returns an empty permission set without calling Keycloak. Set this to false
+    /// for consumers whose Keycloak client does not have the UMA Authorization feature
+    /// enabled (= role-based-only auth). Default: true (preserves prior behavior).
+    /// </summary>
+    /// <remarks>
+    /// Wired automatically by <c>AddBffServices</c> from <c>BffOptions.EnableRptTokens</c>
+    /// and by <c>AddApiServices</c> from <c>ApiAuthOptions.EnableRptTokens</c>.
+    /// </remarks>
+    public bool Enabled { get; set; } = true;
 
     /// <summary>
     /// Default cache expiration time

--- a/affolterNET.Web.Core/Models/AppSettings.cs
+++ b/affolterNET.Web.Core/Models/AppSettings.cs
@@ -15,9 +15,7 @@ public class AppSettings
     /// </summary>
     public AuthenticationMode AuthMode { get; set; }
 
-    public bool IsBff { get; set; }
-
-    public AppSettings() : this(false, AuthenticationMode.None, true)
+    public AppSettings() : this(false, AuthenticationMode.None)
     {
     }
 
@@ -26,11 +24,9 @@ public class AppSettings
     /// </summary>
     /// <param name="isDev">Whether running in development mode</param>
     /// <param name="authMode">Authentication mode</param>
-    /// <param name="isBff"></param>
-    public AppSettings(bool isDev, AuthenticationMode authMode, bool isBff)
+    public AppSettings(bool isDev, AuthenticationMode authMode)
     {
         IsDev = isDev;
         AuthMode = authMode;
-        IsBff = isBff;
     }
 }

--- a/affolterNET.Web.Core/Services/PermissionService.cs
+++ b/affolterNET.Web.Core/Services/PermissionService.cs
@@ -27,6 +27,16 @@ public class PermissionService(
 
     public async Task<IReadOnlyList<Permission>> GetUserPermissionsAsync(string userId, string accessToken, CancellationToken cancellationToken = default)
     {
+        // Master gate: when RPT/permissions are turned off via PermissionCacheOptions.Enabled
+        // (forwarded from BffOptions.EnableRptTokens / ApiAuthOptions.EnableRptTokens),
+        // skip the Keycloak round-trip entirely. Avoids the
+        // "Client does not support permissions" warning on every login for consumers
+        // that use role-based-only authorization.
+        if (!_permissionCacheConfig.Enabled)
+        {
+            return Array.Empty<Permission>();
+        }
+
         if (string.IsNullOrEmpty(userId) || string.IsNullOrEmpty(accessToken))
         {
             return Array.Empty<Permission>();

--- a/affolterNET.Web.Core/affolterNET.Web.Core.csproj
+++ b/affolterNET.Web.Core/affolterNET.Web.Core.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>affolterNET.Web.Core</PackageId>
-    <Version>0.8.4</Version>
+    <Version>0.9.0</Version>
     <Authors>affolterNET</Authors>
     <Description>Core authentication and authorization components for web applications</Description>
     


### PR DESCRIPTION
## Summary

Consolidates RPT-related config behind a single source of truth so consumers using role-based-only auth can opt out cleanly. Closes the long-standing log-spam issue where every authenticated request emitted \`Error fetching RPT: Client does not support permissions\` because the claims-enrichment service called \`PermissionService.GetUserPermissionsAsync\` regardless of \`BffOptions.EnableRptTokens\`.

## Changes

- **PermissionCacheOptions.Enabled** (default \`true\`) is the new master gate. \`PermissionService.GetUserPermissionsAsync\` short-circuits when false, skipping the Keycloak round-trip entirely. \`HasPermissionAsync\` inherits this behaviour because it delegates to \`GetUserPermissionsAsync\`.
- **BffAppOptions.Configure** forwards \`BffOptions.EnableRptTokens → PermissionCache.Enabled\` after user-supplied actions run, so a consumer that does \`bffOpts.EnableRptTokens = false\` silences both \`RptMiddleware\` and the claims-enrichment RPT fetch with a single knob.
- **ApiAppOptions.EnableRptTokens** (default \`true\`) added for parity with Bff. Gates the Api \`RptMiddleware\` registration (previously always-on) and forwards into \`PermissionCache.Enabled\` via the same pattern.
- **AppSettings.IsBff** property and 3rd constructor arg **removed**. Full grep across \`/Users/martin/Source/\` confirms zero read sites — only assignment and one Bexio pass-through. Constructor is now 2-arg (\`isDev\`, \`authMode\`).

**Breaking change:** Callers of \`AppSettings(isDev, authMode, isBff)\` must drop the third arg. Two consumer-side branches are ready: \`affolterNET.Bexio/chore/silence-rpt-warnings\` and \`GP-DataFlow/chore/silence-rpt-warnings\`.

## Tests

- New \`PermissionServiceGateTests.GetUserPermissionsAsync_ReturnsEmpty_WhenDisabled\` — constructs \`PermissionService\` with \`null!\` for \`RptTokenService\`/\`IMemoryCache\`/etc to prove the early-return triggers before any collaborator is touched.
- All 26 existing tests green.

## Versions

Bumps \`affolterNET.Web.Core\`, \`affolterNET.Web.Bff\`, \`affolterNET.Web.Api\` to **0.9.0**.

## Test plan

- [x] \`dotnet build\` clean (0 warnings, 0 errors)
- [x] \`dotnet test\` green (26 tests)
- [x] Local project-reference build of GP-DataFlow against this branch — clean
- [ ] CI publishes 0.9.0
- [ ] Consumer PRs in Bexio + GP-DataFlow merge and verify no RPT warnings on dev